### PR TITLE
feat: add detailed weather metrics and mock mqss api

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,5 @@ bun.lockb
 
 # Miscellaneous
 /static/
+.svelte-kit/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -36,3 +36,21 @@ npm run build
 You can preview the production build with `npm run preview`.
 
 > To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
+
+## Weather station and MQSS mock service
+
+The weather dashboard now consumes data from a small mock MQSS service. The
+service lives inside the SvelteKit app and exposes two endpoints:
+
+- `/api/mqss/weather` – returns the full payload of the latest weather sample.
+- `/api/mqss/weather/[metric]` – returns a single metric block (e.g. `outdoor`,
+  `wind`).
+
+These routes currently serve generated demo data from
+`src/lib/mockWeather.ts`. In production they should be replaced with calls to
+the real MQSS backend that receives weather station updates.
+
+Each metric panel on the `/weather` page expands on hover and links to a
+dedicated detail view showing 24‑hour graphs, highs and lows, and a placeholder
+benchmark from the Bureau of Meteorology. The detail view includes a back button
+styled the same as the home button on the maps page for a consistent UI.

--- a/src/lib/mockWeather.ts
+++ b/src/lib/mockWeather.ts
@@ -1,0 +1,35 @@
+export type Weather = {
+  updatedAt: string;
+  outdoor: { temp: number; trend: number; feelsLike: number; dewPoint: number; humidity: number; vpd: number };
+  indoor: { temp: number; trend: number; humidity: number };
+  solar: { solar: number; uvi: number; sunrise: string; sunset: string; moon: string };
+  rain: { rate: number; daily: number; event: number; hourly: number; weekly: number; monthly: number; yearly: number };
+  wind: { dir: number; speed: number; gust: number; timeSpeed?: string; timeGust?: string };
+  pressure: { rel: number; abs: number; deltaRel: number; deltaAbs: number };
+  battery: { status: 'NORMAL' | 'LOW' | 'CRITICAL'; note?: string };
+  series: { t: number; temp: number; feels: number; dew: number }[];
+};
+
+/**
+ * Returns mock weather data. In production this would be replaced with
+ * requests to the real MQSS backend.
+ */
+export function getMockWeather(): Weather {
+  const now = new Date();
+  return {
+    updatedAt: now.toISOString(),
+    outdoor: { temp: 12.2, trend: 0.8, feelsLike: 12.2, dewPoint: 5.6, humidity: 64, vpd: 0.511 },
+    indoor: { temp: 14.5, trend: -1.4, humidity: 57 },
+    solar: { solar: 306.2, uvi: 2, sunrise: '06:25', sunset: '17:57', moon: 'Waning Gibbous' },
+    rain: { rate: 0, daily: 0, event: 31.8, hourly: 0, weekly: 33.6, monthly: 33.6, yearly: 33.6 },
+    wind: { dir: 221, speed: 8.6, gust: 18.4, timeSpeed: '09:46', timeGust: '00:07' },
+    pressure: { rel: 993.7, abs: 993.7, deltaRel: -0.2, deltaAbs: -0.2 },
+    battery: { status: 'NORMAL', note: 'Sensor Array' },
+    series: Array.from({ length: 48 }).map((_, i) => ({
+      t: i,
+      temp: 6 + i * 0.12 + Math.sin(i / 3) * 0.5,
+      feels: 5.5 + i * 0.1 + Math.sin(i / 4) * 0.4,
+      dew: 3 + Math.sin(i / 5) * 0.3
+    }))
+  };
+}

--- a/src/lib/mqss.ts
+++ b/src/lib/mqss.ts
@@ -1,0 +1,21 @@
+import type { Weather } from './mockWeather';
+
+/**
+ * Fetch full weather payload from the mock MQSS endpoint.
+ */
+export async function fetchWeather(fetchFn: typeof fetch = fetch): Promise<Weather> {
+  const res = await fetchFn('/api/mqss/weather');
+  const data = (await res.json()) as Weather;
+  return data;
+}
+
+/**
+ * Fetch a single weather metric from the mock MQSS endpoint.
+ */
+export async function fetchMetric(metric: string, fetchFn: typeof fetch = fetch): Promise<unknown> {
+  const res = await fetchFn(`/api/mqss/weather/${metric}`);
+  if (!res.ok) {
+    throw new Error(`Unknown metric: ${metric}`);
+  }
+  return res.json();
+}

--- a/src/routes/api/mqss/weather/+server.ts
+++ b/src/routes/api/mqss/weather/+server.ts
@@ -1,0 +1,7 @@
+import { json } from '@sveltejs/kit';
+import { getMockWeather } from '$lib/mockWeather';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = () => {
+  return json(getMockWeather());
+};

--- a/src/routes/api/mqss/weather/[metric]/+server.ts
+++ b/src/routes/api/mqss/weather/[metric]/+server.ts
@@ -1,0 +1,13 @@
+import { json, error } from '@sveltejs/kit';
+import { getMockWeather } from '$lib/mockWeather';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = ({ params }) => {
+  const data = getMockWeather();
+  const metric = params.metric as keyof typeof data;
+  if (metric in data) {
+    // @ts-ignore dynamic index
+    return json(data[metric]);
+  }
+  throw error(404, 'Unknown metric');
+};

--- a/src/routes/weather/+page.svelte
+++ b/src/routes/weather/+page.svelte
@@ -1,17 +1,12 @@
 <script lang="ts">
   import Panel from '$lib/components/Panel.svelte';
   import { onMount } from 'svelte';
+  import type { Weather } from '$lib/mockWeather';
 
-  type Weather = {
-    updatedAt: Date;
-    outdoor: { temp: number; trend: number; feelsLike: number; dewPoint: number; humidity: number; vpd: number };
-    indoor: { temp: number; trend: number; humidity: number };
-    solar: { solar: number; uvi: number; sunrise: string; sunset: string; moon: string };
-    rain: { rate: number; daily: number; event: number; hourly: number; weekly: number; monthly: number; yearly: number };
-    wind: { dir: number; speed: number; gust: number; timeSpeed?: string; timeGust?: string };
-    pressure: { rel: number; abs: number; deltaRel: number; deltaAbs: number };
-    battery: { status: 'NORMAL' | 'LOW' | 'CRITICAL'; note?: string };
-    series: { t: number; temp: number; feels: number; dew: number }[];
+  export let data: { w: Weather };
+  let w: Weather & { updatedAt: Date } = {
+    ...data.w,
+    updatedAt: new Date(data.w.updatedAt)
   };
 
   const now = () => new Date();
@@ -21,24 +16,6 @@
   function arrow(n: number) {
     return n > 0 ? '↑' : n < 0 ? '↓' : '→';
   }
-
-  // Seed with realistic demo values (replace with real API later)
-  let w: Weather = {
-    updatedAt: now(),
-    outdoor: { temp: 12.2, trend: 0.8, feelsLike: 12.2, dewPoint: 5.6, humidity: 64, vpd: 0.511 },
-    indoor: { temp: 14.5, trend: -1.4, humidity: 57 },
-    solar: { solar: 306.2, uvi: 2, sunrise: '06:25', sunset: '17:57', moon: 'Waning Gibbous' },
-    rain: { rate: 0, daily: 0, event: 31.8, hourly: 0, weekly: 33.6, monthly: 33.6, yearly: 33.6 },
-    wind: { dir: 221, speed: 8.6, gust: 18.4, timeSpeed: '09:46', timeGust: '00:07' },
-    pressure: { rel: 993.7, abs: 993.7, deltaRel: -0.2, deltaAbs: -0.2 },
-    battery: { status: 'NORMAL', note: 'Sensor Array' },
-    series: Array.from({ length: 48 }).map((_, i) => ({
-      t: i,
-      temp: 6 + i * 0.12 + Math.sin(i / 3) * 0.5,
-      feels: 5.5 + i * 0.1 + Math.sin(i / 4) * 0.4,
-      dew: 3 + Math.sin(i / 5) * 0.3
-    }))
-  };
 
   let secondsAgo = 0;
   onMount(() => {
@@ -61,121 +38,135 @@
 
 <main class="container mx-auto px-4 pb-8 space-y-5">
   <div class="grid gap-4 lg:grid-cols-3 xl:grid-cols-4">
-    <Panel title="Outdoor">
-      <div class="grid grid-cols-2 gap-4">
-        <div>
-          <div class="text-muted text-xs mb-1">Temperature</div>
-          <div class="text-3xl font-semibold">{fmt(w.outdoor.temp)}<span class="text-base align-top"> °C</span></div>
-          <div class="text-xs text-muted mt-1">{arrow(w.outdoor.trend)} {fmt(Math.abs(w.outdoor.trend))} °C/hr</div>
-          <div class="text-xs text-muted mt-1">↗ 12.7 °C ↘ 4.9 °C</div>
-          <div class="text-xs text-accent mt-1">VPD {fmt(w.outdoor.vpd, 3)} kPa</div>
-        </div>
-        <div>
-          <div class="text-muted text-xs mb-1">Humidity</div>
-          <div class="text-3xl font-semibold">{w.outdoor.humidity}<span class="text-base align-top"> %</span></div>
-          <div class="text-xs text-muted mt-1">Feels Like {fmt(w.outdoor.feelsLike)} °C</div>
-          <div class="text-xs text-muted mt-1">Dew Point {fmt(w.outdoor.dewPoint)} °C</div>
-        </div>
-      </div>
-    </Panel>
-
-    <Panel title="Indoor">
-      <div class="grid grid-cols-2 gap-4">
-        <div>
-          <div class="text-muted text-xs mb-1">Temperature</div>
-          <div class="text-3xl font-semibold">{fmt(w.indoor.temp)}<span class="text-base align-top"> °C</span></div>
-          <div class="text-xs text-muted mt-1">{arrow(w.indoor.trend)} {fmt(Math.abs(w.indoor.trend))} °C/hr</div>
-          <div class="text-xs text-muted mt-1">↗ 14.6 °C ↘ 11.6 °C</div>
-        </div>
-        <div>
-          <div class="text-muted text-xs mb-1">Humidity</div>
-          <div class="text-3xl font-semibold">{w.indoor.humidity}<span class="text-base align-top"> %</span></div>
-          <div class="text-xs text-muted mt-1">↗ 64 % ↘ 56 %</div>
-        </div>
-      </div>
-    </Panel>
-
-    <Panel title="Solar and UVI">
-      <div class="grid grid-cols-2 gap-4">
-        <div>
-          <div class="text-muted text-xs">{w.solar.moon}</div>
-          <div class="mt-2">
-            <div class="text-muted text-xs mb-1">Solar</div>
-            <div class="text-3xl font-semibold">{fmt(w.solar.solar)}<span class="text-base align-top"> W/m²</span></div>
-            <div class="text-xs text-muted mt-1">↗ 828.9 W/m²</div>
+    <a href="/weather/outdoor" class="block transform transition hover:scale-105">
+      <Panel title="Outdoor" className="h-full">
+        <div class="grid grid-cols-2 gap-4">
+          <div>
+            <div class="text-muted text-xs mb-1">Temperature</div>
+            <div class="text-3xl font-semibold">{fmt(w.outdoor.temp)}<span class="text-base align-top"> °C</span></div>
+            <div class="text-xs text-muted mt-1">{arrow(w.outdoor.trend)} {fmt(Math.abs(w.outdoor.trend))} °C/hr</div>
+            <div class="text-xs text-muted mt-1">↗ 12.7 °C ↘ 4.9 °C</div>
+            <div class="text-xs text-accent mt-1">VPD {fmt(w.outdoor.vpd, 3)} kPa</div>
+          </div>
+          <div>
+            <div class="text-muted text-xs mb-1">Humidity</div>
+            <div class="text-3xl font-semibold">{w.outdoor.humidity}<span class="text-base align-top"> %</span></div>
+            <div class="text-xs text-muted mt-1">Feels Like {fmt(w.outdoor.feelsLike)} °C</div>
+            <div class="text-xs text-muted mt-1">Dew Point {fmt(w.outdoor.dewPoint)} °C</div>
           </div>
         </div>
-        <div>
-          <div class="text-muted text-xs mb-1">UVI</div>
-          <div class="text-3xl font-semibold">{w.solar.uvi}</div>
-          <div class="text-xs text-muted mt-4">☀ Sun Rise {w.solar.sunrise}</div>
-          <div class="text-xs text-muted">☀ Sun Set {w.solar.sunset}</div>
-        </div>
-      </div>
-    </Panel>
+      </Panel>
+    </a>
 
-    <Panel title="Rainfall">
-      <div class="grid grid-cols-2 gap-4">
-        <div>
-          <div class="text-muted text-xs mb-1">Rain Rate /hr</div>
-          <div class="text-3xl font-semibold">{fmt(w.rain.rate)}<span class="text-base align-top"> mm</span></div>
-          <div class="text-xs text-muted mt-2">Daily {fmt(w.rain.daily)} mm</div>
+    <a href="/weather/indoor" class="block transform transition hover:scale-105">
+      <Panel title="Indoor" className="h-full">
+        <div class="grid grid-cols-2 gap-4">
+          <div>
+            <div class="text-muted text-xs mb-1">Temperature</div>
+            <div class="text-3xl font-semibold">{fmt(w.indoor.temp)}<span class="text-base align-top"> °C</span></div>
+            <div class="text-xs text-muted mt-1">{arrow(w.indoor.trend)} {fmt(Math.abs(w.indoor.trend))} °C/hr</div>
+            <div class="text-xs text-muted mt-1">↗ 14.6 °C ↘ 11.6 °C</div>
+          </div>
+          <div>
+            <div class="text-muted text-xs mb-1">Humidity</div>
+            <div class="text-3xl font-semibold">{w.indoor.humidity}<span class="text-base align-top"> %</span></div>
+            <div class="text-xs text-muted mt-1">↗ 64 % ↘ 56 %</div>
+          </div>
         </div>
-        <div class="text-xs text-muted space-y-1">
-          <div>Event <span class="text-green-400">{fmt(w.rain.event)} mm</span></div>
-          <div>Hourly {fmt(w.rain.hourly)} mm</div>
-          <div>Weekly {fmt(w.rain.weekly)} mm</div>
-          <div>Monthly {fmt(w.rain.monthly)} mm</div>
-          <div>Yearly {fmt(w.rain.yearly)} mm</div>
-        </div>
-      </div>
-    </Panel>
+      </Panel>
+    </a>
 
-    <Panel title="Wind" className="xl:col-span-2">
-      <div class="grid grid-cols-3 gap-4 items-center">
-        <div class="col-span-2 flex items-center justify-center">
-          <!-- Simple wind dial -->
-          <svg viewBox="0 0 120 120" class="w-52 h-52">
-            <circle cx="60" cy="60" r="54" class="fill-transparent stroke-border" stroke-width="2" />
-            <text x="60" y="64" text-anchor="middle" class="fill-white text-3xl font-semibold">{Math.round(w.wind.dir)}</text>
-            <text x="60" y="84" text-anchor="middle" class="fill-muted text-xs">{['N','NE','E','SE','S','SW','W','NW'][Math.round(((w.wind.dir%360)+22.5)/45)%8]}</text>
-            <g transform={`rotate(${w.wind.dir} 60 60)`}>
-              <polygon points="60,12 56,24 64,24" class="fill-accent" />
-            </g>
-          </svg>
+    <a href="/weather/solar" class="block transform transition hover:scale-105">
+      <Panel title="Solar and UVI" className="h-full">
+        <div class="grid grid-cols-2 gap-4">
+          <div>
+            <div class="text-muted text-xs">{w.solar.moon}</div>
+            <div class="mt-2">
+              <div class="text-muted text-xs mb-1">Solar</div>
+              <div class="text-3xl font-semibold">{fmt(w.solar.solar)}<span class="text-base align-top"> W/m²</span></div>
+              <div class="text-xs text-muted mt-1">↗ 828.9 W/m²</div>
+            </div>
+          </div>
+          <div>
+            <div class="text-muted text-xs mb-1">UVI</div>
+            <div class="text-3xl font-semibold">{w.solar.uvi}</div>
+            <div class="text-xs text-muted mt-4">☀ Sun Rise {w.solar.sunrise}</div>
+            <div class="text-xs text-muted">☀ Sun Set {w.solar.sunset}</div>
+          </div>
         </div>
-        <div class="text-sm text-muted">
-          <div class="text-white text-lg font-semibold">Wind {fmt(w.wind.speed)} m/s</div>
-          <div>↗ {fmt(w.wind.speed * 3.6)} km/h <span class="text-xs">{w.wind.timeSpeed}</span></div>
-          <div class="mt-2 text-white text-lg font-semibold">Gust {fmt(w.wind.gust)} m/s</div>
-          <div>↗ {fmt(w.wind.gust * 3.6)} km/h <span class="text-xs">{w.wind.timeGust}</span></div>
-        </div>
-      </div>
-    </Panel>
+      </Panel>
+    </a>
 
-    <Panel title="Pressure">
-      <div class="grid grid-cols-2 gap-4">
-        <div>
-          <div class="text-muted text-xs mb-1">Relative</div>
-          <div class="text-3xl font-semibold">{fmt(w.pressure.rel, 1)}<span class="text-base align-top"> hPa</span></div>
-          <div class="text-xs text-muted mt-1">{arrow(w.pressure.deltaRel)} {fmt(Math.abs(w.pressure.deltaRel),1)} hPa</div>
-          <div class="text-xs text-muted mt-1">↗ 994.2 hPa ↘ 990.1 hPa</div>
+    <a href="/weather/rain" class="block transform transition hover:scale-105">
+      <Panel title="Rainfall" className="h-full">
+        <div class="grid grid-cols-2 gap-4">
+          <div>
+            <div class="text-muted text-xs mb-1">Rain Rate /hr</div>
+            <div class="text-3xl font-semibold">{fmt(w.rain.rate)}<span class="text-base align-top"> mm</span></div>
+            <div class="text-xs text-muted mt-2">Daily {fmt(w.rain.daily)} mm</div>
+          </div>
+          <div class="text-xs text-muted space-y-1">
+            <div>Event <span class="text-green-400">{fmt(w.rain.event)} mm</span></div>
+            <div>Hourly {fmt(w.rain.hourly)} mm</div>
+            <div>Weekly {fmt(w.rain.weekly)} mm</div>
+            <div>Monthly {fmt(w.rain.monthly)} mm</div>
+            <div>Yearly {fmt(w.rain.yearly)} mm</div>
+          </div>
         </div>
-        <div>
-          <div class="text-muted text-xs mb-1">Absolute</div>
-          <div class="text-3xl font-semibold">{fmt(w.pressure.abs, 1)}<span class="text-base align-top"> hPa</span></div>
-          <div class="text-xs text-muted mt-1">{arrow(w.pressure.deltaAbs)} {fmt(Math.abs(w.pressure.deltaAbs),1)} hPa</div>
-          <div class="text-xs text-muted mt-1">↗ 994.2 hPa ↘ 990.1 hPa</div>
-        </div>
-      </div>
-    </Panel>
+      </Panel>
+    </a>
 
-    <Panel title="Battery">
-      <div class="text-sm">
-        <div class="text-green-400 font-semibold">{w.battery.status}</div>
-        <div class="text-muted">{w.battery.note}</div>
-      </div>
-    </Panel>
+    <a href="/weather/wind" class="block transform transition hover:scale-105 xl:col-span-2">
+      <Panel title="Wind" className="h-full">
+        <div class="grid grid-cols-3 gap-4 items-center">
+          <div class="col-span-2 flex items-center justify-center">
+            <!-- Simple wind dial -->
+            <svg viewBox="0 0 120 120" class="w-52 h-52">
+              <circle cx="60" cy="60" r="54" class="fill-transparent stroke-border" stroke-width="2" />
+              <text x="60" y="64" text-anchor="middle" class="fill-white text-3xl font-semibold">{Math.round(w.wind.dir)}</text>
+              <text x="60" y="84" text-anchor="middle" class="fill-muted text-xs">{['N','NE','E','SE','S','SW','W','NW'][Math.round(((w.wind.dir%360)+22.5)/45)%8]}</text>
+              <g transform={`rotate(${w.wind.dir} 60 60)`}>
+                <polygon points="60,12 56,24 64,24" class="fill-accent" />
+              </g>
+            </svg>
+          </div>
+          <div class="text-sm text-muted">
+            <div class="text-white text-lg font-semibold">Wind {fmt(w.wind.speed)} m/s</div>
+            <div>↗ {fmt(w.wind.speed * 3.6)} km/h <span class="text-xs">{w.wind.timeSpeed}</span></div>
+            <div class="mt-2 text-white text-lg font-semibold">Gust {fmt(w.wind.gust)} m/s</div>
+            <div>↗ {fmt(w.wind.gust * 3.6)} km/h <span class="text-xs">{w.wind.timeGust}</span></div>
+          </div>
+        </div>
+      </Panel>
+    </a>
+
+    <a href="/weather/pressure" class="block transform transition hover:scale-105">
+      <Panel title="Pressure" className="h-full">
+        <div class="grid grid-cols-2 gap-4">
+          <div>
+            <div class="text-muted text-xs mb-1">Relative</div>
+            <div class="text-3xl font-semibold">{fmt(w.pressure.rel, 1)}<span class="text-base align-top"> hPa</span></div>
+            <div class="text-xs text-muted mt-1">{arrow(w.pressure.deltaRel)} {fmt(Math.abs(w.pressure.deltaRel),1)} hPa</div>
+            <div class="text-xs text-muted mt-1">↗ 994.2 hPa ↘ 990.1 hPa</div>
+          </div>
+          <div>
+            <div class="text-muted text-xs mb-1">Absolute</div>
+            <div class="text-3xl font-semibold">{fmt(w.pressure.abs, 1)}<span class="text-base align-top"> hPa</span></div>
+            <div class="text-xs text-muted mt-1">{arrow(w.pressure.deltaAbs)} {fmt(Math.abs(w.pressure.deltaAbs),1)} hPa</div>
+            <div class="text-xs text-muted mt-1">↗ 994.2 hPa ↘ 990.1 hPa</div>
+          </div>
+        </div>
+      </Panel>
+    </a>
+
+    <a href="/weather/battery" class="block transform transition hover:scale-105">
+      <Panel title="Battery" className="h-full">
+        <div class="text-sm">
+          <div class="text-green-400 font-semibold">{w.battery.status}</div>
+          <div class="text-muted">{w.battery.note}</div>
+        </div>
+      </Panel>
+    </a>
   </div>
 
   <!-- Simple trend chart -->

--- a/src/routes/weather/+page.ts
+++ b/src/routes/weather/+page.ts
@@ -1,0 +1,7 @@
+import type { PageLoad } from './$types';
+import { fetchWeather } from '$lib/mqss';
+
+export const load: PageLoad = async ({ fetch }) => {
+  const w = await fetchWeather(fetch);
+  return { w };
+};

--- a/src/routes/weather/[metric]/+page.svelte
+++ b/src/routes/weather/[metric]/+page.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import type { Weather } from '$lib/mockWeather';
+
+  export let data: { metric: string; w: Weather };
+  const metric = data.metric;
+  const w = data.w;
+
+  const titles: Record<string, string> = {
+    outdoor: 'Outdoor',
+    indoor: 'Indoor',
+    solar: 'Solar and UVI',
+    rain: 'Rainfall',
+    wind: 'Wind',
+    pressure: 'Pressure',
+    battery: 'Battery'
+  };
+  const title = titles[metric] ?? metric;
+
+  // Simple 24hr temperature series from the mock data
+  const series = w.series;
+  const xs = (t: number) => 40 + (t / 47) * 740;
+  const ys = (v: number) => 200 - (v / 14) * 180;
+  const high = Math.max(...series.map((p) => p.temp));
+  const low = Math.min(...series.map((p) => p.temp));
+  const bom = { high: 13, low: 5 };
+</script>
+
+<div class="relative container mx-auto px-4 pb-8">
+  <a href="/weather" aria-label="Back to weather"
+    class="absolute top-3 left-3 z-[1000] rounded-full border border-border bg-panel/95 backdrop-blur px-3 py-2 text-sm text-white hover:bg-panel focus:outline-none focus:ring-2 focus:ring-accent/40 shadow-md flex items-center gap-2">
+    <!-- arrow-left icon -->
+    <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="size-5" viewBox="0 0 24 24"><path d="M10.5 6 4.5 12l6 6M4.5 12h15" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+    <span class="hidden sm:inline">Back</span>
+  </a>
+
+  <h1 class="text-2xl font-semibold text-center mt-12 mb-6">{title}</h1>
+
+  <section class="mb-6 text-center">
+    <div class="text-xl font-semibold">High {high.toFixed(1)}°C / Low {low.toFixed(1)}°C</div>
+    <div class="text-sm text-muted">BoM Benchmark: High {bom.high}°C, Low {bom.low}°C</div>
+  </section>
+
+  <section class="overflow-x-auto">
+    <svg viewBox="0 0 800 240" class="w-full h-64">
+      <defs>
+        <clipPath id="clipDetail">
+          <rect x="40" y="20" width="740" height="180" />
+        </clipPath>
+      </defs>
+      <g clip-path="url(#clipDetail)">
+        <polyline fill="none" stroke="#facc15" stroke-width="2" points={series.map(p => `${xs(p.t)},${ys(p.temp)}`).join(' ')} />
+      </g>
+      <g class="text-muted">
+        <line x1="40" y1="200" x2="780" y2="200" stroke="currentColor" stroke-opacity="0.3" />
+        <text x="782" y="204" class="fill-muted text-xs">0</text>
+      </g>
+    </svg>
+  </section>
+</div>

--- a/src/routes/weather/[metric]/+page.ts
+++ b/src/routes/weather/[metric]/+page.ts
@@ -1,0 +1,7 @@
+import type { PageLoad } from './$types';
+import { fetchWeather } from '$lib/mqss';
+
+export const load: PageLoad = async ({ params, fetch }) => {
+  const w = await fetchWeather(fetch);
+  return { metric: params.metric, w };
+};


### PR DESCRIPTION
## Summary
- add mock MQSS API service and client helpers
- make weather dashboard panels hover-expand and link to detail pages
- add detail pages with 24h graph and back button styled like map home
- document MQSS endpoints in README

## Testing
- `npm run lint` *(fails: Code style issues found in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68c04bc552708327af755f66d64deaa2