### PR TITLE
feat: load paddock data from sqlite

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
 		"@sveltejs/kit": "^2.22.0",
 		"@sveltejs/vite-plugin-svelte": "^6.0.0",
 		"@tailwindcss/vite": "^4.0.0",
+		"@types/better-sqlite3": "^7.6.13",
+		"@types/leaflet": "^1.9.20",
+		"@types/node": "^24.3.1",
 		"eslint": "^9.18.0",
 		"eslint-config-prettier": "^10.0.1",
 		"eslint-plugin-svelte": "^3.0.0",
@@ -35,6 +38,7 @@
 		"vite": "^7.0.4"
 	},
 	"dependencies": {
+		"better-sqlite3": "^9.6.0",
 		"leaflet": "^1.9.4"
 	}
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,19 +1,18 @@
 const CONFIG = {
-  data: {
-    geojson: "/api/data/farm", // backend endpoint (or keep "data/farm.geojson")
-    optima: "/api/data/optima",
-    bounds: "/api/data/bounds",
-  },
-  tiles: {
-    url: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
-    attribution:
-      "Imagery © Esri, Maxar, Earthstar Geographics, and the GIS community",
-    maxZoom: 20,
-  },
-  metrics: ["OM", "P1", "K", "MG", "CA", "PH"], // keep your list
-  defaultMetric: "OM",
-  palette: ["#f7d200", "#b3e472", "#16a34a", "#89e472", "#b91c1c"],
-  maxDevFactor: 1.5,
+	data: {
+		// Backend endpoints serving paddock and related data from the database
+		geojson: '/api/data/farm',
+		optima: '/api/data/optima',
+		bounds: '/api/data/bounds'
+	},
+	tiles: {
+		url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+		attribution: 'Imagery © Esri, Maxar, Earthstar Geographics, and the GIS community',
+		maxZoom: 20
+	},
+	metrics: ['OM', 'P1', 'K', 'MG', 'CA', 'PH'], // keep your list
+	defaultMetric: 'OM',
+	palette: ['#f7d200', '#b3e472', '#16a34a', '#89e472', '#b91c1c'],
+	maxDevFactor: 1.5
 };
 export default CONFIG;
-

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -1,0 +1,25 @@
+import Database from 'better-sqlite3';
+import { resolve } from 'path';
+
+// Use the same SQLite database as the weather service so both can run
+// inside the same container. Prefer the WEATHER_DB_PATH env variable but
+// fall back to DB_PATH or a sensible default.
+const dbPath = resolve(process.env.WEATHER_DB_PATH || process.env.DB_PATH || 'weather.db');
+const db = new Database(dbPath);
+
+// Ensure paddock table exists. Feel free to extend schema elsewhere as needed.
+db.exec(`CREATE TABLE IF NOT EXISTS paddock (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  farm TEXT,
+  year TEXT,
+  OM REAL,
+  P1 REAL,
+  K REAL,
+  MG REAL,
+  CA REAL,
+  PH REAL,
+  geometry TEXT
+)`);
+
+export default db;

--- a/src/routes/api/data/farm/+server.ts
+++ b/src/routes/api/data/farm/+server.ts
@@ -21,22 +21,33 @@ export const GET: RequestHandler = () => {
 		.prepare('SELECT id, name, farm, year, OM, P1, K, MG, CA, PH, geometry FROM paddock')
 		.all() as PaddockRow[];
 
-	const features = rows.map((r) => ({
-		type: 'Feature',
-		geometry: r.geometry ? JSON.parse(r.geometry) : null,
-		properties: {
-			fieldID: r.id,
-			fieldName: r.name,
-			FARM: r.farm,
-			ADSYEAR: r.year,
-			OM: r.OM,
-			P1: r.P1,
-			K: r.K,
-			MG: r.MG,
-			CA: r.CA,
-			PH: r.PH
+	const features = rows.map((r) => {
+		let geometry = null;
+		if (r.geometry) {
+			try {
+				geometry = JSON.parse(r.geometry);
+			} catch (e) {
+				geometry = null;
+				// Optionally log the error here if desired
+			}
 		}
-	}));
+		return {
+			type: 'Feature',
+			geometry,
+			properties: {
+				fieldID: r.id,
+				fieldName: r.name,
+				FARM: r.farm,
+				ADSYEAR: r.year,
+				OM: r.OM,
+				P1: r.P1,
+				K: r.K,
+				MG: r.MG,
+				CA: r.CA,
+				PH: r.PH
+			}
+		};
+	});
 
 	return json({
 		type: 'FeatureCollection',

--- a/src/routes/api/data/farm/+server.ts
+++ b/src/routes/api/data/farm/+server.ts
@@ -1,0 +1,45 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import db from '$lib/server/db';
+
+interface PaddockRow {
+	id: string;
+	name: string;
+	farm: string | null;
+	year: string | null;
+	OM: number | null;
+	P1: number | null;
+	K: number | null;
+	MG: number | null;
+	CA: number | null;
+	PH: number | null;
+	geometry: string | null;
+}
+
+// GET /api/data/farm -> GeoJSON FeatureCollection of paddocks
+export const GET: RequestHandler = () => {
+	const rows = db
+		.prepare('SELECT id, name, farm, year, OM, P1, K, MG, CA, PH, geometry FROM paddock')
+		.all() as PaddockRow[];
+
+	const features = rows.map((r) => ({
+		type: 'Feature',
+		geometry: r.geometry ? JSON.parse(r.geometry) : null,
+		properties: {
+			fieldID: r.id,
+			fieldName: r.name,
+			FARM: r.farm,
+			ADSYEAR: r.year,
+			OM: r.OM,
+			P1: r.P1,
+			K: r.K,
+			MG: r.MG,
+			CA: r.CA,
+			PH: r.PH
+		}
+	}));
+
+	return json({
+		type: 'FeatureCollection',
+		features
+	});
+};


### PR DESCRIPTION
## Summary
- add SQLite-backed paddock table with automatic schema init
- expose `/api/data/farm` endpoint to serve paddock data from DB
- document paddock endpoints in config and add required dependencies
- share SQLite database with weather service via `WEATHER_DB_PATH`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Code style issues found in 24 files)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c3f283e8488327aa6cf16c4676cf5b