### PR TITLE
feat: show metric readings log

### DIFF
--- a/src/routes/weather/[metric]/+page.svelte
+++ b/src/routes/weather/[metric]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Weather } from '$lib/weather';
 
-	export let data: { metric: string; w: Weather; log: unknown };
+	export let data: { metric: string; w: Weather; log: Record<string, any>[] };
 	const metric = data.metric;
 	const w = data.w;
 	const log = Array.isArray(data.log) ? data.log : [];

--- a/src/routes/weather/[metric]/+page.svelte
+++ b/src/routes/weather/[metric]/+page.svelte
@@ -5,7 +5,13 @@
 	const metric = data.metric;
 	const w = data.w;
 	const log = Array.isArray(data.log) ? data.log : [];
-	const headers = log.length ? Object.keys(log[0]) : [];
+	const headers =
+		log.length &&
+		log[0] !== null &&
+		typeof log[0] === 'object' &&
+		!Array.isArray(log[0])
+			? Object.keys(log[0])
+			: [];
 
 	const titles: Record<string, string> = {
 		outdoor: 'Outdoor',

--- a/src/routes/weather/[metric]/+page.svelte
+++ b/src/routes/weather/[metric]/+page.svelte
@@ -97,7 +97,7 @@
 						{#each log as row}
 							<tr>
 								{#each headers as h}
-									<td class="border-b px-2 py-1">{row[h]}</td>
+									<td class="border-b px-2 py-1">{row?.[h] ?? ''}</td>
 								{/each}
 							</tr>
 						{/each}

--- a/src/routes/weather/[metric]/+page.svelte
+++ b/src/routes/weather/[metric]/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import type { Weather } from '$lib/weather';
 
-	export let data: { metric: string; w: Weather };
+	export let data: { metric: string; w: Weather; log: unknown };
 	const metric = data.metric;
 	const w = data.w;
+	const log = Array.isArray(data.log) ? data.log : [];
+	const headers = log.length ? Object.keys(log[0]) : [];
 
 	const titles: Record<string, string> = {
 		outdoor: 'Outdoor',
@@ -71,5 +73,33 @@
 				<text x="782" y="204" class="fill-muted text-xs">0</text>
 			</g>
 		</svg>
+	</section>
+
+	<section class="mt-8">
+		<h2 class="mb-2 text-lg font-semibold">Recent readings</h2>
+		{#if log.length}
+			<div class="overflow-x-auto">
+				<table class="min-w-full text-left text-sm">
+					<thead>
+						<tr>
+							{#each headers as h}
+								<th class="border-b px-2 py-1 font-medium">{h}</th>
+							{/each}
+						</tr>
+					</thead>
+					<tbody>
+						{#each log as row}
+							<tr>
+								{#each headers as h}
+									<td class="border-b px-2 py-1">{row[h]}</td>
+								{/each}
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{:else}
+			<p class="text-muted text-sm">No recent readings available.</p>
+		{/if}
 	</section>
 </div>

--- a/src/routes/weather/[metric]/+page.ts
+++ b/src/routes/weather/[metric]/+page.ts
@@ -1,7 +1,19 @@
 import type { PageLoad } from './$types';
-import { fetchWeather } from '$lib/weather';
+import { fetchMetric, fetchWeather } from '$lib/weather';
 
-export const load: PageLoad = async ({ params }) => {
+export const load: PageLoad = async ({ params, fetch }) => {
 	const res = await fetchWeather();
-	return { metric: params.metric, w: res.weather, connected: res.connected, source: res.source };
+	let log: unknown = [];
+	try {
+		log = await fetchMetric(params.metric, fetch);
+	} catch (_) {
+		log = [];
+	}
+	return {
+		metric: params.metric,
+		w: res.weather,
+		connected: res.connected,
+		source: res.source,
+		log
+	};
 };


### PR DESCRIPTION
## Summary
- fetch metric-specific readings and expose them to the metric page
- render a table of recent readings for the selected metric

## Testing
- `npm run lint` *(fails: Code style issues found in 15 files. Run Prettier with --write to fix.)*
- `npm run check` *(fails: svelte-check found 3 errors and 1 warning in 4 files)*

------
https://chatgpt.com/codex/tasks/task_e_68c56afd9ae88327aaa7bff8519ce9af